### PR TITLE
feat: add UI flow for private challenge invite requests

### DIFF
--- a/src/components/challenge/InviteUserDialog.tsx
+++ b/src/components/challenge/InviteUserDialog.tsx
@@ -1,0 +1,231 @@
+import React, { useState, useRef } from "react";
+import { Search, UserPlus, Loader2, Check } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { inviteApi, userApi } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+import { UserSearchResult } from "@/types";
+import { cn } from "@/lib/utils";
+
+interface InviteUserDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  challengeId: string;
+  challengeName: string;
+  existingMemberIds?: string[];
+}
+
+const InviteUserDialog: React.FC<InviteUserDialogProps> = ({
+  open,
+  onOpenChange,
+  challengeId,
+  challengeName,
+  existingMemberIds = [],
+}) => {
+  const { toast } = useToast();
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<UserSearchResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [invitedIds, setInvitedIds] = useState<Set<string>>(new Set());
+  const [sendingId, setSendingId] = useState<string | null>(null);
+  const searchTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleSearch = (value: string) => {
+    setQuery(value);
+
+    if (searchTimeoutRef.current) {
+      clearTimeout(searchTimeoutRef.current);
+    }
+
+    if (value.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+
+    searchTimeoutRef.current = setTimeout(async () => {
+      setIsSearching(true);
+      try {
+        const response = await userApi.searchUsers(value.trim());
+        if (response.success && response.data) {
+          setResults(response.data as UserSearchResult[]);
+        } else {
+          setResults([]);
+        }
+      } catch {
+        setResults([]);
+      } finally {
+        setIsSearching(false);
+      }
+    }, 400);
+  };
+
+  const handleSendInvite = async (user: UserSearchResult) => {
+    setSendingId(user.id);
+    try {
+      const response = await inviteApi.sendInvite(challengeId, user.id);
+      if (response.success) {
+        setInvitedIds((prev) => new Set(prev).add(user.id));
+        toast({
+          title: "Invite sent",
+          description: `Invite sent to ${user.username} successfully.`,
+        });
+      } else {
+        throw new Error(response.message || "Failed to send invite");
+      }
+    } catch (error: unknown) {
+      const message =
+        (error as { response?: { data?: { message?: string } }; message?: string })
+          ?.response?.data?.message ??
+        (error as { message?: string })?.message ??
+        "Please try again.";
+      toast({
+        title: "Failed to send invite",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setSendingId(null);
+    }
+  };
+
+  const handleOpenChange = (value: boolean) => {
+    if (!value) {
+      setQuery("");
+      setResults([]);
+      setInvitedIds(new Set());
+    }
+    onOpenChange(value);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <UserPlus className="h-5 w-5" />
+            Invite Users
+          </DialogTitle>
+          <DialogDescription>
+            Search for users to invite to{" "}
+            <span className="font-medium text-foreground">{challengeName}</span>.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          {/* Search Input */}
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder="Search by username..."
+              value={query}
+              onChange={(e) => handleSearch(e.target.value)}
+              className="pl-9"
+              autoFocus
+            />
+          </div>
+
+          {/* Results */}
+          <ScrollArea className="h-64">
+            {isSearching && (
+              <div className="flex items-center justify-center py-8">
+                <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+              </div>
+            )}
+
+            {!isSearching && query.trim().length >= 2 && results.length === 0 && (
+              <p className="text-center text-sm text-muted-foreground py-8">
+                No users found for {"\""}{query}{"\""}
+              </p>
+            )}
+
+            {!isSearching && query.trim().length < 2 && (
+              <p className="text-center text-sm text-muted-foreground py-8">
+                Type at least 2 characters to search
+              </p>
+            )}
+
+            {!isSearching && results.length > 0 && (
+              <div className="space-y-2 pr-2">
+                {results.map((user) => {
+                  const isAlreadyMember = existingMemberIds.includes(user.id);
+                  const isInvited = invitedIds.has(user.id);
+                  const isSending = sendingId === user.id;
+
+                  return (
+                    <div
+                      key={user.id}
+                      className="flex items-center gap-3 p-3 rounded-lg border hover:bg-muted/50 transition-colors"
+                    >
+                      <Avatar className="h-9 w-9">
+                        <AvatarImage src={user.avatar} alt={user.username} />
+                        <AvatarFallback>
+                          {user.username.charAt(0).toUpperCase()}
+                        </AvatarFallback>
+                      </Avatar>
+
+                      <div className="flex-1 min-w-0">
+                        <p className="font-medium text-sm truncate">
+                          {user.username}
+                        </p>
+                        <p className="text-xs text-muted-foreground truncate">
+                          LC: {user.leetcodeUsername}
+                        </p>
+                      </div>
+
+                      {isAlreadyMember ? (
+                        <Badge
+                          variant="outline"
+                          className="text-xs shrink-0"
+                        >
+                          Member
+                        </Badge>
+                      ) : isInvited ? (
+                        <Badge
+                          variant="outline"
+                          className={cn(
+                            "text-xs shrink-0 gap-1",
+                            "bg-success/10 text-success border-success/20"
+                          )}
+                        >
+                          <Check className="h-3 w-3" />
+                          Invited
+                        </Badge>
+                      ) : (
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="shrink-0 gap-1.5"
+                          onClick={() => handleSendInvite(user)}
+                          disabled={isSending}
+                        >
+                          {isSending ? (
+                            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                          ) : (
+                            <UserPlus className="h-3.5 w-3.5" />
+                          )}
+                          Invite
+                        </Button>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            )}
+          </ScrollArea>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default InviteUserDialog;

--- a/src/components/dashboard/InviteRequests.tsx
+++ b/src/components/dashboard/InviteRequests.tsx
@@ -1,0 +1,197 @@
+import React, { useState, useEffect, useCallback } from "react";
+import { CheckCircle2, XCircle, Mail, Loader2, Trophy } from "lucide-react";
+import { Link } from "react-router-dom";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { inviteApi } from "@/lib/api";
+import { useToast } from "@/hooks/use-toast";
+import { ChallengeInvite } from "@/types";
+import { cn } from "@/lib/utils";
+
+const InviteRequests: React.FC = () => {
+  const { toast } = useToast();
+  const [invites, setInvites] = useState<ChallengeInvite[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [respondingId, setRespondingId] = useState<string | null>(null);
+
+  const loadInvites = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await inviteApi.getMyInvites();
+      if (response.success && response.data) {
+        const pending = (response.data as ChallengeInvite[]).filter(
+          (inv) => inv.status === "pending"
+        );
+        setInvites(pending);
+      }
+    } catch {
+      // Silently fail — not critical for dashboard render
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadInvites();
+  }, [loadInvites]);
+
+  const handleRespond = async (
+    invite: ChallengeInvite,
+    action: "accepted" | "rejected"
+  ) => {
+    setRespondingId(invite.id);
+    try {
+      const response = await inviteApi.respondToInvite(invite.id, action);
+      if (response.success) {
+        // Remove the invite from the list regardless of action
+        setInvites((prev) => prev.filter((inv) => inv.id !== invite.id));
+        toast({
+          title:
+            action === "accepted" ? "Invite accepted!" : "Invite declined",
+          description:
+            action === "accepted"
+              ? `You have joined "${invite.challengeName}". Visit the challenge page to get started.`
+              : `You have declined the invite to "${invite.challengeName}".`,
+        });
+      } else {
+        throw new Error(response.message || "Failed to respond to invite");
+      }
+    } catch (error: unknown) {
+      const message =
+        (error as { response?: { data?: { message?: string } }; message?: string })
+          ?.response?.data?.message ??
+        (error as { message?: string })?.message ??
+        "Please try again.";
+      toast({
+        title: "Action failed",
+        description: message,
+        variant: "destructive",
+      });
+    } finally {
+      setRespondingId(null);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-xl flex items-center gap-2">
+            <Mail className="h-5 w-5" />
+            Challenge Invites
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center py-6">
+            <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (invites.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-xl flex items-center gap-2">
+            <Mail className="h-5 w-5" />
+            Challenge Invites
+          </CardTitle>
+          <Badge variant="secondary" className="text-sm">
+            {invites.length} pending
+          </Badge>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {invites.map((invite) => {
+            const isResponding = respondingId === invite.id;
+
+            return (
+              <div
+                key={invite.id}
+                className={cn(
+                  "flex flex-col sm:flex-row sm:items-center gap-3 p-4 rounded-lg border",
+                  "bg-muted/30 hover:bg-muted/50 transition-colors"
+                )}
+              >
+                {/* Challenge Info */}
+                <div className="flex items-center gap-3 flex-1 min-w-0">
+                  <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-primary/10">
+                    <Trophy className="h-5 w-5 text-primary" />
+                  </div>
+                  <div className="min-w-0">
+                    <p className="font-medium truncate">{invite.challengeName}</p>
+                    <p className="text-sm text-muted-foreground">
+                      Invited by{" "}
+                      <span className="font-medium text-foreground">
+                        {invite.senderName}
+                      </span>
+                    </p>
+                  </div>
+                </div>
+
+                {/* Action Buttons */}
+                <div className="flex items-center gap-2 shrink-0">
+                  <Button
+                    size="sm"
+                    className={cn(
+                      "gap-1.5",
+                      "bg-success/10 text-success border-success/20 hover:bg-success/20",
+                      "border"
+                    )}
+                    variant="ghost"
+                    onClick={() => handleRespond(invite, "accepted")}
+                    disabled={isResponding}
+                  >
+                    {isResponding ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <CheckCircle2 className="h-3.5 w-3.5" />
+                    )}
+                    Accept
+                  </Button>
+                  <Button
+                    size="sm"
+                    className={cn(
+                      "gap-1.5",
+                      "bg-destructive/10 text-destructive border-destructive/20 hover:bg-destructive/20",
+                      "border"
+                    )}
+                    variant="ghost"
+                    onClick={() => handleRespond(invite, "rejected")}
+                    disabled={isResponding}
+                  >
+                    {isResponding ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <XCircle className="h-3.5 w-3.5" />
+                    )}
+                    Decline
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    asChild
+                  >
+                    <Link to={`/challenge/${invite.challengeId}`}>
+                      View
+                    </Link>
+                  </Button>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};
+
+export default InviteRequests;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -198,6 +198,44 @@ export const challengeApi = {
 };
 
 // ============================================================================
+// INVITE APIs
+// ============================================================================
+export const inviteApi = {
+  sendInvite: async (challengeId: string, userId: string) => {
+    const response = await api.post<ApiResponse<any>>(
+      `/api/challenges/${challengeId}/invites`,
+      { userId }
+    );
+    return response.data;
+  },
+
+  getMyInvites: async () => {
+    const response = await api.get<ApiResponse<any[]>>("/api/invites");
+    return response.data;
+  },
+
+  respondToInvite: async (inviteId: string, action: "accepted" | "rejected") => {
+    const response = await api.patch<ApiResponse<any>>(
+      `/api/invites/${inviteId}`,
+      { action }
+    );
+    return response.data;
+  },
+};
+
+// ============================================================================
+// USER APIs
+// ============================================================================
+export const userApi = {
+  searchUsers: async (query: string) => {
+    const response = await api.get<ApiResponse<any[]>>("/api/users/search", {
+      params: { q: query },
+    });
+    return response.data;
+  },
+};
+
+// ============================================================================
 // DASHBOARD APIs
 // ============================================================================
 export const dashboardApi = {

--- a/src/pages/ChallengePage.tsx
+++ b/src/pages/ChallengePage.tsx
@@ -10,6 +10,7 @@ import {
   Settings,
   Loader2,
   PlayCircle,
+  UserPlus,
 } from "lucide-react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
@@ -18,6 +19,7 @@ import { Progress } from "@/components/ui/progress";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import Layout from "@/components/layout/Layout";
 import MembersList from "@/components/challenge/MembersList";
+import InviteUserDialog from "@/components/challenge/InviteUserDialog";
 import ProgressChart from "@/components/dashboard/ProgressChart";
 import { mockChartData } from "@/data/mockData";
 import { cn } from "@/lib/utils";
@@ -41,6 +43,7 @@ const ChallengePage: React.FC = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [isJoining, setIsJoining] = useState(false);
   const [isActivating, setIsActivating] = useState(false);
+  const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
 
   useEffect(() => {
     if (id) {
@@ -231,6 +234,17 @@ const ChallengePage: React.FC = () => {
                   Activate Challenge
                 </Button>
               )}
+            {challenge.isPrivate && challenge.ownerId === user?.id && (
+              <Button
+                variant="outline"
+                size="sm"
+                className="gap-2"
+                onClick={() => setIsInviteDialogOpen(true)}
+              >
+                <UserPlus className="h-4 w-4" />
+                Invite Users
+              </Button>
+            )}
             <Button
               variant="outline"
               size="sm"
@@ -374,6 +388,17 @@ const ChallengePage: React.FC = () => {
           </TabsContent>
         </Tabs>
       </div>
+
+      {/* Invite Users Dialog — only rendered for private challenge owners */}
+      {challenge.isPrivate && challenge.ownerId === user?.id && (
+        <InviteUserDialog
+          open={isInviteDialogOpen}
+          onOpenChange={setIsInviteDialogOpen}
+          challengeId={challenge.id}
+          challengeName={challenge.name}
+          existingMemberIds={leaderboard.map((m) => m.userId || m.id)}
+        />
+      )}
     </Layout>
   );
 };

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -8,6 +8,7 @@ import TodayStatus from "@/components/dashboard/TodayStatus";
 import ProgressChart from "@/components/dashboard/ProgressChart";
 import ActivityHeatmap from "@/components/dashboard/ActivityHeatmap";
 import ChallengeCard from "@/components/dashboard/ChallengeCard";
+import InviteRequests from "@/components/dashboard/InviteRequests";
 import EmptyState from "@/components/common/EmptyState";
 import { useAuth } from "@/contexts/AuthContext";
 import { dashboardApi, challengeApi } from "@/lib/api";
@@ -158,6 +159,9 @@ const Dashboard: React.FC = () => {
             variant="destructive"
           />
         </div>
+
+        {/* Invite Requests */}
+        <InviteRequests />
 
         {/* Main Grid */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,25 @@ export interface Challenge {
   createdBy: string;
   members: ChallengeMember[];
   isActive: boolean;
+  isPrivate?: boolean;
+}
+
+export interface ChallengeInvite {
+  id: string;
+  challengeId: string;
+  challengeName: string;
+  senderId: string;
+  senderName: string;
+  receiverId: string;
+  status: 'pending' | 'accepted' | 'rejected';
+  createdAt: string;
+}
+
+export interface UserSearchResult {
+  id: string;
+  username: string;
+  leetcodeUsername: string;
+  avatar?: string;
 }
 
 export interface ChallengeMember {


### PR DESCRIPTION
 Team Number :Team 146

## Description
Implements the complete UI flow for private challenge invite requests. Challenge owners can search for users by username and send invite requests directly from the challenge page. Invited users see pending invites on their dashboard and can accept or reject them. Accepted members gain immediate access to the private challenge, and rejected invites are removed from the dashboard.

## Related Issue
Closes #6

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Changes Made
- Added `ChallengeInvite` and `UserSearchResult` types to `src/types/index.ts`, and `isPrivate` flag on `Challenge`
- Added `inviteApi` (sendInvite, getMyInvites, respondToInvite) and `userApi` (searchUsers) to `src/lib/api.ts`
- Created `src/components/challenge/InviteUserDialog.tsx` — debounced user search dialog for challenge owners to find and invite users; shows "Member" badge for existing members and "Invited" badge after invite is sent
- Created `src/components/dashboard/InviteRequests.tsx` — dashboard card listing all pending invites with Accept / Decline buttons; card auto-hides when no pending invites exist
- Updated `src/pages/ChallengePage.tsx` — added "Invite Users" button visible only to the owner of a private challenge
- Updated `src/pages/Dashboard.tsx` — renders InviteRequests section between stats grid and main content

## Testing
- [x] Tested on Desktop (Chrome/Firefox/Safari)
- [x] Tested responsive design (different screen sizes)
- [x] No console errors or warnings
- [x] Code builds successfully (`npm run build`)
- [x] TypeScript check passes (`tsc --noEmit` exits 0)
- [x] No lint errors in new files

## Checklist
- [x] My code follows the project's code style guidelines
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] I have tested my changes thoroughly
- [x] All TypeScript types are properly defined
- [x] Tailwind CSS classes are used appropriately (no inline styles)
- [x] Component is responsive across different screen sizes
- [x] I have read and followed the CONTRIBUTING.md guidelines