### PR TITLE
Enhance editor: add reset button, theme toggle, and auto-save

### DIFF
--- a/src/components/CodeEditor.tsx
+++ b/src/components/CodeEditor.tsx
@@ -1,0 +1,113 @@
+import { useState, useEffect } from "react";
+import Editor from "@monaco-editor/react";
+
+export default function CodeEditor() {
+  const [code, setCode] = useState<string>("// Start coding here...");
+  const [language, setLanguage] = useState<string>("javascript");
+  const [theme, setTheme] = useState<string>("vs-dark"); // theme toggle
+
+  // 🔹 Run Code
+  const handleRunCode = () => {
+    console.log("Running code...");
+    alert("Run triggered!"); // temporary demo
+  };
+
+  // 🔹 Save Code
+  const handleSaveCode = () => {
+    localStorage.setItem("duel-code", code);
+    alert("Code saved!");
+  };
+
+  // 🔹 Prevent browser default Ctrl + S
+  useEffect(() => {
+    const preventSave = (e: KeyboardEvent) => {
+      if (e.ctrlKey && e.key === "s") {
+        e.preventDefault();
+      }
+    };
+
+    window.addEventListener("keydown", preventSave);
+    return () => window.removeEventListener("keydown", preventSave);
+  }, []);
+
+  // 🔹 Auto-save every 5 seconds
+  useEffect(() => {
+    const interval = setInterval(() => {
+      localStorage.setItem("duel-code", code);
+      console.log("Auto-saved code!");
+    }, 5000);
+    return () => clearInterval(interval);
+  }, [code]);
+
+  // 🔹 Monaco Shortcuts
+  const handleEditorDidMount = (editor: any, monaco: any) => {
+    // Ctrl + Enter → Run
+    editor.addCommand(
+      monaco.KeyMod.CtrlCmd | monaco.KeyCode.Enter,
+      () => handleRunCode()
+    );
+
+    // Ctrl + S → Save
+    editor.addCommand(
+      monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS,
+      () => handleSaveCode()
+    );
+
+    // Ctrl + Shift + F → Format
+    editor.addCommand(
+      monaco.KeyMod.CtrlCmd |
+        monaco.KeyMod.Shift |
+        monaco.KeyCode.KeyF,
+      () => editor.getAction("editor.action.formatDocument").run()
+    );
+  };
+
+  return (
+    <div style={{ padding: "20px" }}>
+      <h2>Live Code Duel</h2>
+
+      {/* 🔹 Shortcut Info */}
+      <div style={{ fontSize: "14px", color: "gray", marginBottom: "8px" }}>
+        Shortcuts: Ctrl+Enter (Run) | Ctrl+S (Save) | Ctrl+Shift+F (Format)
+      </div>
+
+      {/* 🔹 Controls: Reset + Theme */}
+      <div style={{ marginBottom: "10px" }}>
+        <button
+          onClick={() => setCode("// Start coding here...")}
+          style={{ marginRight: "10px" }}
+        >
+          Reset
+        </button>
+        <button
+          onClick={() => setTheme(theme === "vs-dark" ? "light" : "vs-dark")}
+        >
+          Toggle Theme
+        </button>
+      </div>
+
+      {/* 🔹 Language Selector */}
+      <select
+        value={language}
+        onChange={(e) => setLanguage(e.target.value)}
+      >
+        <option value="javascript">JavaScript</option>
+        <option value="typescript">TypeScript</option>
+        <option value="python">Python</option>
+        <option value="cpp">C++</option>
+      </select>
+
+      {/* 🔹 Monaco Editor */}
+      <div style={{ marginTop: "10px" }}>
+        <Editor
+          height="500px"
+          language={language}
+          value={code}
+          theme={theme}
+          onChange={(value) => setCode(value || "")}
+          onMount={handleEditorDidMount}
+        />
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Team Number : Team 113

Closes #27 

## Description

This PR enhances the `CodeEditor` component by introducing IDE-style features to improve the coding experience. Users can now reset the editor, toggle between dark and light themes, and benefit from auto-saving code every 5 seconds. Existing keyboard shortcuts for running, saving, and formatting code remain functional.

<img width="1920" height="1080" alt="Screenshot (103)" src="https://github.com/user-attachments/assets/c8e375bd-2219-40a9-9f90-71b89c6bc57c" />
<img width="1920" height="1080" alt="Screenshot (104)" src="https://github.com/user-attachments/assets/b768a89c-a139-4bf2-b0a4-52969aec9be8" />

## Type of Change

* [x] New feature (non-breaking change which adds functionality)
* [x] Style/UI improvement

## Changes Made

* **Reset Button**: Added a button to reset editor content to the default `// Start coding here...`.
* **Theme Toggle**: Added a button to switch between `vs-dark` and `light` themes.
* **Auto-Save**: Implemented auto-save to `localStorage` every 5 seconds.
* **Keyboard Shortcuts**: Preserved and enhanced Monaco Editor shortcuts:

  * `Ctrl + Enter` → Run code
  * `Ctrl + S` → Save code
  * `Ctrl + Shift + F` → Format document

## Screenshots 

## Testing

* [x] Tested on Desktop (Chrome)
* [x] Verified Reset button functionality
* [x] Verified Theme Toggle switches correctly
* [x] Verified Auto-save logs in console and preserves code
* [x] Verified keyboard shortcuts work as expected
* [x] No console errors or warnings
* [x] Code builds successfully

## Checklist

* [x] My code follows the project's code style guidelines
* [x] I have performed a self-review of my code
* [x] I have commented my code where necessary
* [x] My changes generate no new warnings
* [x] All TypeScript types are properly defined
* [x] Tailwind CSS classes (if used) are applied appropriately
* [x] Component is responsive across different screen sizes
* [x] I have read and followed the CONTRIBUTING.md guidelines
