### PR TITLE
fix: preserve attempted route on login (T102, fixes #38)

### DIFF
--- a/src/components/common/ProtectedRoute.tsx
+++ b/src/components/common/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Navigate } from "react-router-dom";
+import { Navigate, useLocation } from "react-router-dom";
 import { useAuth } from "@/contexts/AuthContext";
 import { Loader2 } from "lucide-react";
 
@@ -9,6 +9,7 @@ interface ProtectedRouteProps {
 
 const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   const { isAuthenticated, isLoading } = useAuth();
+  const location = useLocation();
 
   if (isLoading) {
     return (
@@ -19,7 +20,7 @@ const ProtectedRoute: React.FC<ProtectedRouteProps> = ({ children }) => {
   }
 
   if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
+    return <Navigate to="/login" replace state={{ from: location }} />;
   }
 
   return <>{children}</>;

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import { Code2, Eye, EyeOff, Loader2 } from 'lucide-react';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -16,6 +16,7 @@ const Login: React.FC = () => {
   
   const { login, isLoading } = useAuth();
   const navigate = useNavigate();
+  const location = useLocation();
   const { toast } = useToast();
 
   const validate = () => {
@@ -49,7 +50,8 @@ const Login: React.FC = () => {
         title: 'Welcome back!',
         description: 'Successfully logged in.',
       });
-      navigate('/');
+      const from = (location.state as any)?.from?.pathname || '/';
+      navigate(from, { replace: true });
     } catch {
       toast({
         title: 'Login failed',


### PR DESCRIPTION
## Team Number : Team 102

## Description
This PR preserves the originally requested route when redirecting unauthenticated users to login. "ProtectedRoute.tsx" now stores the attempted location in the navigation state and "Login.tsx" reads that state and navigates back after successful authentication.

## Related Issue 
Closes #38

## Type of Change
-  Bug fix (non-breaking change which fixes incorrect redirect behavior)
- [x] UX improvement

## Changes Made
-   Pass current location when redirecting to login from "ProtectRoute.tsx"
- Edited src/components/common/ProtectedRoute.tsx
Read saved "from" location in "Login.tsx" and navigate back after successful login 
- Edited src/pages/Login.tsx

Testing

-  [x] Manual test: attempted route preserved and user redirected back after login
-  [x] I have performed a self-review of my code
-  [x] I have included Team T102 and referenced the issue #38
-  [x] All TypeScript types are preserved (no type changes required)

Files Changed

- src/components/common/ProtectedRoute.tsx
- src/pages/Login.tsx