### PR TITLE
fix: close mobile nav after navigation

### DIFF
--- a/src/components/layout/Navbar.tsx
+++ b/src/components/layout/Navbar.tsx
@@ -123,6 +123,7 @@ const Navbar: React.FC = () => {
                     <SheetClose asChild key={to}>
                       <Link
                         to={to}
+                        onClick={() => setMobileOpen(false)}
                         className="flex items-center gap-3 rounded-md px-3 py-2.5 text-sm font-medium transition-colors hover:bg-accent hover:text-accent-foreground"
                       >
                         <Icon className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- ensure mobile sheet closes when tapping any nav link

## Rationale
- mobile menu stayed open after navigation; UX should mirror desktop where nav disappears after selection

## Changes
- add onClick handler to mobile nav links to toggle sheet closed

## Tests
- tested locally in fork

Fixes #56